### PR TITLE
Let user can choice a candidate when run copy or move command.

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -374,29 +374,29 @@ class AppBuffer(BrowserBuffer):
     def move_current_or_mark_file(self):
         mark_number = len(self.vue_get_mark_files())
 
-        destination_path = get_emacs_func_result("eaf-file-browser-get-destination-path", [])
+        destination_paths = get_emacs_func_result("eaf-file-browser-get-destination-paths", [])
 
         if mark_number > 0:
             self.move_files = self.vue_get_mark_files()
-            self.send_input_message("Move mark files to: ", "move_files", "file", destination_path)
+            self.send_input_message("Move mark files to: ", "move_files", "file", "", destination_paths)
         else:
             self.move_file = self.vue_get_select_file()
             if self.move_file != None:
-                self.send_input_message("Move '{}' to: ".format(self.move_file["name"]), "move_file", "file", destination_path)
+                self.send_input_message("Move '{}' to: ".format(self.move_file["name"]), "move_file", "file", "", destination_paths)
 
     @interactive
     def copy_current_or_mark_file(self):
         mark_number = len(self.vue_get_mark_files())
 
-        destination_path = get_emacs_func_result("eaf-file-browser-get-destination-path", [])
+        destination_paths = get_emacs_func_result("eaf-file-browser-get-destination-paths", [])
 
         if mark_number > 0:
             self.copy_files = self.vue_get_mark_files()
-            self.send_input_message("Copy mark files to: ", "copy_files", "file", destination_path)
+            self.send_input_message("Copy mark files to: ", "copy_files", "file", "", destination_paths)
         else:
             self.copy_file = self.vue_get_select_file()
             if self.copy_file != None:
-                self.send_input_message("Copy '{}' to: ".format(self.copy_file["name"]), "copy_file", "file", destination_path)
+                self.send_input_message("Copy '{}' to: ".format(self.copy_file["name"]), "copy_file", "file", "", destination_paths)
 
     @interactive
     def batch_rename(self):

--- a/eaf-file-manager.el
+++ b/eaf-file-manager.el
@@ -189,8 +189,13 @@
     (when (= (length values) 1)
       (car values))))
 
-(defun eaf-file-browser-get-destination-path ()
-  "Get a destination path, which is used for copy or move command."
+(defun eaf-file-browser-get-destination-paths ()
+  "Get a list of destination paths, user will select one of which
+for copy or move command."
+  (list (eaf-file-browser-get-other-window-path)))
+
+(defun eaf-file-browser-get-other-window-path ()
+  "Get the directory of eaf app in other window."
   (save-window-excursion
     (other-window 1)
     (let ((window-path (if (derived-mode-p 'eaf-mode)


### PR DESCRIPTION
eaf-file-browser-get-destination-path -> eaf-file-browser-get-destination-paths

This feature need eaf send_input_message support collection argument.

A user case is like below

(defun eh-eaf-file-browser-get-destination-paths ()
  (list (eaf-file-browser-get-other-window-path)
        "~/Download"
        "~/Public"
        "~/"))
(advice-add 'eaf-file-browser-get-destination-paths :override #'eh-eaf-file-browser-get-destination-paths)